### PR TITLE
Enables GPU compute capability 5.0 for Maxwell based GPUs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,7 @@ if(APPLE)
 endif()
 
 set(CUDA_NVCC_FLAGS
-  -gencode=arch=compute_20,code=sm_20;-gencode=arch=compute_30,code=sm_30;-gencode=arch=compute_35,code=sm_35)
+  -gencode=arch=compute_20,code=sm_20;-gencode=arch=compute_30,code=sm_30;-gencode=arch=compute_35,code=sm_35;-gencode=arch=compute_50,code=sm_50)
 
 if(WIN32)
   set(CUDA_NVCC_FLAGS
@@ -123,3 +123,4 @@ endif(WIN32)
 
 add_subdirectory(Buffers)
 add_subdirectory(cudaSirecon)
+

--- a/cudaSirecon/CMakeLists.txt
+++ b/cudaSirecon/CMakeLists.txt
@@ -19,13 +19,15 @@ if(WIN32)
         link_directories ( ${TIFF_LIBRARY} )
     endif(WITH_TIFF)
 elseif(APPLE)
-## Assuming the builder's shell environment is already set up to use 64-bit Priism
-	set(PRIISM_LIB_PATH "$ENV{IVE_BASE}/Darwin64/LIB")
-	include_directories("$ENV{IVE_BASE}/Darwin64/INCLUDE/")
+## Not assuming the builder's shell environment is already set up to use 64-bit Priism
+## But rather the priism/ was put in the locate described
+## in the instructions in the top CMakeLists.txt section 1.5
+	set(PRIISM_LIB_PATH "${CMAKE_SOURCE_DIR}/priism-4.4.0/Darwin/x86_64/LIB")
+	include_directories("${CMAKE_SOURCE_DIR}/priism-4.4.0/Darwin/x86_64/INCLUDE")
 else()
-## Assuming the builder's shell environment is already set up to use 64-bit Priism
-	set(PRIISM_LIB_PATH "$ENV{IVE_BASE}/Linux/x86_64/LIB")
-	include_directories("$ENV{IVE_BASE}/Linux/x86_64/INCLUDE/")
+## same as for apple - priism install location - works for chalkie666 
+	set(PRIISM_LIB_PATH "${CMAKE_SOURCE_DIR}/priism-4.4.0/Linux/x86_64/LIB")
+	include_directories("${CMAKE_SOURCE_DIR}/priism-4.4.0/Linux/x86_64/INCLUDE")
 endif(WIN32)
 
 


### PR DESCRIPTION
Hi Ian,
I just got a new nvidia quadro K2200 with a Maxwell GPU that has CUDA compute capability level 5.0
so i fixed up the CMake build code nvcc flags a little to make it work with these newer generation GPUs.
Works for me: 3.5 sec for 1 colour channel, 512x512x46 raw data.
Though you might like to pull that into your repository. 
Best
Dan
